### PR TITLE
Fixed SU2 boundary tags

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
             "type": "python",
             "request": "launch",
             "program": "${workspaceFolder}/src/PyAero.py",
-            "console": "integratedTerminal"
+            "console": "integratedTerminal",
+            "justMyCode": false
         }
     ]
 }

--- a/data/Menus/PToolBar.xml
+++ b/data/Menus/PToolBar.xml
@@ -19,6 +19,8 @@
         <Tool tip='Fit airfoil in view' icon='Fit airfoil.png' handler='fitAirfoilInView'></Tool>
         <Tool tip='Fit all in view' icon='Fit in view.png' handler='onViewAll'></Tool>
         <Tool tip='' icon='' handler='onPass'></Tool>
+        <Tool tip='Run commands' icon='Scenario.png' handler='runCommands'></Tool>
+        <Tool tip='' icon='' handler='onPass'></Tool>
         <Tool tip='About' icon='About.png' handler='onAbout'></Tool>
         <Tool tip='' icon='' handler='onPass'></Tool>
         <Tool tip='Shut down PyAero' icon='Exit.png' handler='onExit'></Tool>

--- a/src/Airfoil.py
+++ b/src/Airfoil.py
@@ -172,10 +172,11 @@ class Airfoil:
         line.pen.setDashPattern([stroke, space, dot, space])
         index_min = np.argmin(self.raw_coordinates[0])
         index_max = np.argmax(self.raw_coordinates[0])
-        line.Line(self.raw_coordinates[0][index_min],
-                  self.raw_coordinates[1][index_min],
-                  self.raw_coordinates[0][index_max],
-                  self.raw_coordinates[1][index_max])
+        x1 = self.raw_coordinates[0][index_min]
+        y1 = self.raw_coordinates[1][index_min]
+        x2 = self.raw_coordinates[0][index_max]
+        y2 = self.raw_coordinates[1][index_max]
+        line.Line(x1, y1, x2, y2)
 
         self.chord = GraphicsItem.GraphicsItem(line)
         self.chord.setAcceptHoverEvents(False)
@@ -282,6 +283,7 @@ class Airfoil:
         if hasattr(self, 'camberline'):
             self.mainwindow.scene.removeItem(self.camberline)
         self.camberline = GraphicsItem.GraphicsItem(camberline)
+        self.camberline.setAcceptHoverEvents(False)
         self.mainwindow.scene.addItem(self.camberline)
         self.mainwindow.centralwidget.cb9.setChecked(True)
         self.mainwindow.centralwidget.cb9.setEnabled(True)

--- a/src/Connect.py
+++ b/src/Connect.py
@@ -147,7 +147,7 @@ class Connect:
         vertices = [(vertex[0], vertex[1]) for vertex in vertices]
 
         # search vertices of all blocks against themselves
-        # finds itself AND multiple connections very fast
+        # finds itself AND multiple connections (i.e. vertices from neighbour blocks)
         # uses Scipy kd-tree for quick nearest-neighbor lookup
         # the distance tolerance is specified via the radius variable
         vertex_and_neighbours = self.getNearestNeighbours(vertices,

--- a/src/GraphicsItemsCollection.py
+++ b/src/GraphicsItemsCollection.py
@@ -74,7 +74,7 @@ class GraphicsCollection:
         self.shape.addPolygon(polygon)
         self.method = 'drawPolygon'
         self.args = [polygon]
-        # in case of an airfoil its the airfoil name (PAirfoil.py)
+        # in case of an airfoil its the airfoil name (Airfoil.py)
         self.name = name
         self.tooltip = name
 

--- a/src/GuiSlots.py
+++ b/src/GuiSlots.py
@@ -339,6 +339,25 @@ class Slots:
         dlg.setLayout(layout)
         dlg.exec_()
 
+    def runCommands(self):
+        '''Automate different actions by simulation button clicks
+        Call directly a function or
+        using click or animateClick on the respective widget
+        # self.parent.centralwidget.toolbox.splineButton.click
+        # self.parent.centralwidget.toolbox.splineButton.animateClick
+        
+        '''        
+        # load the predefined airfoil
+        self.onOpenPredefined()
+        # spline and refine the contour with defaults
+        self.parent.centralwidget.toolbox.spline_and_refine()
+        # add a blunt trailing edge with defaults
+        self.parent.centralwidget.toolbox.makeTrailingEdge()
+        # generate a mesh using defaults
+        self.parent.centralwidget.toolbox.generateMesh()
+        # export the mesh
+        self.parent.centralwidget.toolbox.exportMesh()
+
     def onHelpOnline(self):
         webbrowser.open('http://pyaero.readthedocs.io/en/latest/')
 

--- a/src/Logger.py
+++ b/src/Logger.py
@@ -32,6 +32,8 @@ class GuiHandler(logging.Handler):
 
 def log(mainwindow):
 
+    useGUI = True
+
     if mainwindow == 'file_only':
         useGUI = False
 

--- a/src/Logger.py
+++ b/src/Logger.py
@@ -32,6 +32,9 @@ class GuiHandler(logging.Handler):
 
 def log(mainwindow):
 
+    if mainwindow == 'file_only':
+        useGUI = False
+
     logging.basicConfig(level=logging.INFO)
     # logging.getLogger('') gets the 'root' logger
     # stdout is the only handler initially
@@ -50,23 +53,27 @@ def log(mainwindow):
     console_handler.setLevel(logging.ERROR)
 
     # create a gui handler (for writing to the message dock window)
-    gui_handler = GuiHandler(parent=mainwindow)
-    gui_handler.setLevel(logging.INFO)
+    if useGUI:
+        gui_handler = GuiHandler(parent=mainwindow)
+        gui_handler.setLevel(logging.INFO)
 
     # create specific logging formats
     file_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     console_formatter = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
-    gui_formatter = logging.Formatter('%(levelname)s - %(message)s')
+    if useGUI:
+        gui_formatter = logging.Formatter('%(levelname)s - %(message)s')
 
     # apply formats to handlers
     file_handler.setFormatter(file_formatter)
     console_handler.setFormatter(console_formatter)
-    gui_handler.setFormatter(gui_formatter)
+    if useGUI:
+        gui_handler.setFormatter(gui_formatter)
 
     # add the handlers to the root logger
     logging.getLogger('').addHandler(file_handler)
     logging.getLogger('').addHandler(console_handler)
-    logging.getLogger('').addHandler(gui_handler)
+    if useGUI:
+        logging.getLogger('').addHandler(gui_handler)
 
     # remove the standard handler from the root logger
     # it would log everything to the console automatically

--- a/src/PyAero.py
+++ b/src/PyAero.py
@@ -305,8 +305,11 @@ def main():
         if sys.argv[-1] == '-no-gui':
             print('No batch control file specified.')
             sys.exit()
-        batch_controlfile = sys.argv[-1]
 
+        # prepare logger
+        Logger.log('file_only')
+
+        batch_controlfile = sys.argv[-1]
         batchmode = BatchMode.Batch(app, batch_controlfile, __version__)
         batchmode.run_batch()
 

--- a/src/ToolBox.py
+++ b/src/ToolBox.py
@@ -540,10 +540,10 @@ class Toolbox(QtWidgets.QToolBox):
         box_wake = QtWidgets.QGroupBox('Windtunnel mesh (wake)')
         box_wake.setLayout(vbox)
 
-        createMeshButton = QtWidgets.QPushButton('Create Mesh')
+        self.createMeshButton = QtWidgets.QPushButton('Create Mesh')
         hbl_cm = QtWidgets.QHBoxLayout()
         hbl_cm.addStretch(stretch=1)
-        hbl_cm.addWidget(createMeshButton, stretch=4)
+        hbl_cm.addWidget(self.createMeshButton, stretch=4)
         hbl_cm.addStretch(stretch=1)
 
         # export menu and boundary definitions
@@ -622,7 +622,7 @@ class Toolbox(QtWidgets.QToolBox):
         self.item_msh = QtWidgets.QWidget()
         self.item_msh.setLayout(vbl)
 
-        createMeshButton.clicked.connect(self.generateMesh)
+        self.createMeshButton.clicked.connect(self.generateMesh)
         exportMeshButton.clicked.connect(self.exportMesh)
 
     def itemSplineRefine(self):
@@ -666,10 +666,10 @@ class Toolbox(QtWidgets.QToolBox):
         self.points.setValue(200)
         form.addRow(label, self.points)
 
-        splineButton = QtWidgets.QPushButton('Spline and Refine')
+        self.splineButton = QtWidgets.QPushButton('Spline and Refine')
         hbl = QtWidgets.QHBoxLayout()
         hbl.addStretch(stretch=1)
-        hbl.addWidget(splineButton, stretch=4)
+        hbl.addWidget(self.splineButton, stretch=4)
         hbl.addStretch(stretch=1)
 
         vbox = QtWidgets.QVBoxLayout()
@@ -718,10 +718,10 @@ class Toolbox(QtWidgets.QToolBox):
         self.thickness.setValue(0.4)
         form1.addRow(label, self.thickness)
 
-        trailingButton = QtWidgets.QPushButton('Add Trailing Edge')
+        self.trailingButton = QtWidgets.QPushButton('Add Trailing Edge')
         hbl1 = QtWidgets.QHBoxLayout()
         hbl1.addStretch(stretch=1)
-        hbl1.addWidget(trailingButton, stretch=4)
+        hbl1.addWidget(self.trailingButton, stretch=4)
         hbl1.addStretch(stretch=1)
 
         vbox = QtWidgets.QVBoxLayout()
@@ -751,8 +751,8 @@ class Toolbox(QtWidgets.QToolBox):
         self.item_cm = QtWidgets.QWidget()
         self.item_cm.setLayout(vbl)
 
-        splineButton.clicked.connect(self.spline_and_refine)
-        trailingButton.clicked.connect(self.makeTrailingEdge)
+        self.splineButton.clicked.connect(self.spline_and_refine)
+        self.trailingButton.clicked.connect(self.makeTrailingEdge)
         exportContourButton.clicked.connect(self.exportContour)
 
     def makeToolbox(self):


### PR DESCRIPTION
Now the SU2 export carries also the boundary definitions. The meshio module does not support strings as boundary tags. Thus the "airfoil" definition is tagged by "1", the "inlet" by "2" and the "outlet" by "3".
