### PR TITLE
Add requirements.txt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ src/__pycache__/
 SU2/
 todo.txt
 environment.yml
+!requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+PySide6
+scipy
+numpy
+meshio


### PR DESCRIPTION
requirements.txt file are the standard python way to list dependencies.
See: https://learnpython.com/blog/python-requirements-file/

They allow dependencies install with a single command:
`pip install -r ./requirements.txt`